### PR TITLE
Fix crash when dragging cursor

### DIFF
--- a/src/api/mouse.rs
+++ b/src/api/mouse.rs
@@ -78,9 +78,16 @@ pub fn create(lua: &Lua) -> LuaResult<LuaTable> {
 		"set_position",
 		lua.create_function(|lua, (x, y): (f32, f32)| {
 			let state = lua.app_data_ref::<State>().unwrap();
-			state.window.set_cursor_grab(CursorGrabMode::Locked).unwrap();
+
+			#[cfg(not(target_os = "linux"))]
 			state.window.set_cursor_position(PhysicalPosition::new(x, y)).unwrap();
-			state.window.set_cursor_grab(CursorGrabMode::None).unwrap();
+			#[cfg(target_os = "linux")]
+			{
+				// Wayland: Cursor must be in CursorGrabMode::Locked.
+				state.window.set_cursor_grab(CursorGrabMode::Locked).unwrap();
+				state.window.set_cursor_position(PhysicalPosition::new(x, y)).unwrap();
+				state.window.set_cursor_grab(CursorGrabMode::None).unwrap();
+			}
 			Ok(())
 		})?,
 	)?;

--- a/src/api/mouse.rs
+++ b/src/api/mouse.rs
@@ -78,7 +78,9 @@ pub fn create(lua: &Lua) -> LuaResult<LuaTable> {
 		"set_position",
 		lua.create_function(|lua, (x, y): (f32, f32)| {
 			let state = lua.app_data_ref::<State>().unwrap();
+			state.window.set_cursor_grab(CursorGrabMode::Locked).unwrap();
 			state.window.set_cursor_position(PhysicalPosition::new(x, y)).unwrap();
+			state.window.set_cursor_grab(CursorGrabMode::None).unwrap();
 			Ok(())
 		})?,
 	)?;


### PR DESCRIPTION
# crash report

fix: crash when dragging control
log:
```
[ERROR] thread 'main' panicked at 'called `Result::unwrap()` on an
`Err` value: Os(OsError { line: 901, file: "~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winit-0.30.12/src/platform_impl/linux/wayland/window/state.rs",
error: Misc("cursor position can be set only for locked cursor.") })': src/api/mouse.rs:81
```
occured in a linux environment when dragging controls
```
Operating System: Fedora Linux 43
KDE Plasma Version: 6.5.3
KDE Frameworks Version: 6.20.0
Qt Version: 6.10.1
Kernel Version: 6.17.10-300.fc43.x86_64 (64-bit)
Graphics Platform: Wayland
Graphics Processor: Intel® Arc
```